### PR TITLE
let resolve '$VAR with text'

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,10 +1,10 @@
 'use strict'
 
 function expandValue (obj, value) {
-  var ndx = value.indexOf(' ')
-  var endOfVar = ndx === -1 ? undefined : ndx
+  var match = value.match(/[ \/]/)
+  var endOfVar = match ? match.index : undefined
   var possible = value.substring(1, endOfVar)
-  var suffix = ndx === -1 ? '' : value.substring(ndx)
+  var suffix = match ? value.substring(match.index) : ''
   // process.env value 'wins' over .env file's value
   value = process.env[possible] || obj[possible] || ''
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,11 +1,14 @@
 'use strict'
 
 function expandValue (obj, value) {
-  var possible = value.substring(1)
+  var ndx = value.indexOf(' ')
+  var endOfVar = ndx === -1 ? undefined : ndx
+  var possible = value.substring(1, endOfVar)
+  var suffix = ndx === -1 ? '' : value.substring(ndx)
   // process.env value 'wins' over .env file's value
   value = process.env[possible] || obj[possible] || ''
 
-  return value
+  return value + suffix
 }
 
 var expand = function (obj) {

--- a/test/main.js
+++ b/test/main.js
@@ -72,6 +72,18 @@ describe('dotenv-expand', function () {
       obj['ESCAPED_EXPAND'].should.eql('$ESCAPED')
       done()
     })
+
+    it('handles if there are variable and string', function (done) {
+      var dotenv = {
+        'NAME': 'dotenv',
+        'NAME_WITH_TEXT': '$NAME is the module\'s name'
+      }
+
+      var obj = dotenvExpand(dotenv)
+
+      obj['NAME_WITH_TEXT'].should.eql('dotenv is the module\'s name')
+      done()
+    })
   })
 
   describe('integration', function () {

--- a/test/main.js
+++ b/test/main.js
@@ -73,7 +73,7 @@ describe('dotenv-expand', function () {
       done()
     })
 
-    it('handles if there are variable and string', function (done) {
+    it('handles if there are variable and space', function (done) {
       var dotenv = {
         'NAME': 'dotenv',
         'NAME_WITH_TEXT': '$NAME is the module\'s name'
@@ -82,6 +82,18 @@ describe('dotenv-expand', function () {
       var obj = dotenvExpand(dotenv)
 
       obj['NAME_WITH_TEXT'].should.eql('dotenv is the module\'s name')
+      done()
+    })
+
+    it('handles if there are variable and backspace', function (done) {
+      var dotenv = {
+        'BASE_URL': 'http://localhost',
+        'URL': '$BASE_URL/profile'
+      }
+
+      var obj = dotenvExpand(dotenv)
+
+      obj['URL'].should.eql('http://localhost/profile')
       done()
     })
   })


### PR DESCRIPTION
Hey, we were facing an issue in our app where we wanted to do the following:

```
BASE_URL=http://localhost:3000
CDN_URL=$BASE_URL/path
```

So I added this feature, basically I was needed to find the end of the string.

Right now it is able to find slash and space (`/`, ` `). I added tests for both cases, shall I add integration tests as well?