### PR TITLE
Make the algorithm more robust

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -4,34 +4,36 @@ var dotenvExpand = function (config) {
   // if ignoring process.env, use a blank object
   var environment = config.ignoreProcessEnv ? {} : process.env
 
-  var interpolate = function (env) {
-    var matches = env.match(/\$([a-zA-Z0-9_]+)|\${([a-zA-Z0-9_]+)}/g) || []
+  var interpolate = function (envValue) {
+    var matches = envValue.match(/(.?\${?(?:[a-zA-Z0-9_]+)?}?)/g) || []
 
-    matches.forEach(function (match) {
-      var key = match.replace(/\$|{|}/g, '')
+    return matches.reduce(function (newEnv, match) {
+      var parts = /(.?)\${?([a-zA-Z0-9_]+)?}?/g.exec(match)
+      var $prefix = parts[1]
 
-      // process.env value 'wins' over .env file's value
-      var variable = environment.hasOwnProperty(key) ? environment[key] : (config.parsed[key] || '')
+      var value, replacePart
 
-      // Resolve recursive interpolations
-      variable = interpolate(variable)
+      if ($prefix === '\\') {
+        replacePart = parts[0]
+        value = replacePart.replace('\\$', '$')
+      } else {
+        var key = parts[2]
+        replacePart = parts[0].substring($prefix.length)
+        // process.env value 'wins' over .env file's value
+        value = environment.hasOwnProperty(key) ? environment[key] : (config.parsed[key] || '')
 
-      env = env.replace(match, variable)
-    })
+        // Resolve recursive interpolations
+        value = interpolate(value)
+      }
 
-    return env
+      return newEnv.replace(replacePart, value)
+    }, envValue)
   }
 
   for (var configKey in config.parsed) {
     var value = environment.hasOwnProperty(configKey) ? environment[configKey] : config.parsed[configKey]
 
-    if (config.parsed[configKey].substring(0, 2) === '\\$') {
-      config.parsed[configKey] = value.substring(1)
-    } else if (config.parsed[configKey].indexOf('\\$') > 0) {
-      config.parsed[configKey] = value.replace(/\\\$/g, '$')
-    } else {
-      config.parsed[configKey] = interpolate(value)
-    }
+    config.parsed[configKey] = interpolate(value)
   }
 
   for (var processKey in config.parsed) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,16 +9,16 @@ var dotenvExpand = function (config) {
 
     return matches.reduce(function (newEnv, match) {
       var parts = /(.?)\${?([a-zA-Z0-9_]+)?}?/g.exec(match)
-      var $prefix = parts[1]
+      var prefix = parts[1]
 
       var value, replacePart
 
-      if ($prefix === '\\') {
+      if (prefix === '\\') {
         replacePart = parts[0]
         value = replacePart.replace('\\$', '$')
       } else {
         var key = parts[2]
-        replacePart = parts[0].substring($prefix.length)
+        replacePart = parts[0].substring(prefix.length)
         // process.env value 'wins' over .env file's value
         value = environment.hasOwnProperty(key) ? environment[key] : (config.parsed[key] || '')
 

--- a/test/main.js
+++ b/test/main.js
@@ -112,6 +112,31 @@ describe('dotenv-expand', function () {
       obj['SOME_ENV'].should.eql('production')
       done()
     })
+
+    it('does not expand inline escaped dollar sign', function (done) {
+      var dotenv = {
+        parsed: {
+          'INLINE_ESCAPED_EXPAND_BCRYPT': '\\$this\\$is\\$bcrypt'
+        }
+      }
+      var obj = dotenvExpand(dotenv).parsed
+
+      obj['INLINE_ESCAPED_EXPAND_BCRYPT'].should.eql('$this$is$bcrypt')
+      done()
+    })
+
+    it('handle mixed values', function (done) {
+      var dotenv = {
+        parsed: {
+          'PARAM1': '42',
+          'MIXED_VALUES': '\\$this$PARAM1\\$is${PARAM1}'
+        }
+      }
+      var obj = dotenvExpand(dotenv).parsed
+
+      obj['MIXED_VALUES'].should.eql('$this42$is42')
+      done()
+    })
   })
 
   describe('integration', function () {

--- a/test/main.js
+++ b/test/main.js
@@ -116,12 +116,12 @@ describe('dotenv-expand', function () {
     it('does not expand inline escaped dollar sign', function (done) {
       var dotenv = {
         parsed: {
-          'INLINE_ESCAPED_EXPAND_BCRYPT': '\\$this\\$is\\$bcrypt'
+          'INLINE_ESCAPED_EXPAND_BCRYPT': '\\$2b\\$10\\$OMZ69gxxsmRgwAt945WHSujpr/u8ZMx.xwtxWOCMkeMW7p3XqKYca'
         }
       }
       var obj = dotenvExpand(dotenv).parsed
 
-      obj['INLINE_ESCAPED_EXPAND_BCRYPT'].should.eql('$this$is$bcrypt')
+      obj['INLINE_ESCAPED_EXPAND_BCRYPT'].should.eql('$2b$10$OMZ69gxxsmRgwAt945WHSujpr/u8ZMx.xwtxWOCMkeMW7p3XqKYca')
       done()
     })
 


### PR DESCRIPTION
This PR fixes #20

A short explanation of the algorithm: 
1. extract all the $params with the prefix char of the `$` sign
2. break each one of the individual match to parts that will contain the $ prefix char, key.
3. condition, if the prefix is escape char, replace the escape char to nothing, 
    else, replace recursively like before.