### PR TITLE
Add "repository" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "posttest": "npm run lint",
     "lint": "standard"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/motdotla/dotenv-expand.git"
+  },
   "keywords": [
     "dotenv",
     "expand",


### PR DESCRIPTION
Having this field set is especially nice for when people are viewing the package on [npmjs.com](https://www.npmjs.com/package/dotenv-expand) as it provides a link back to the source code here on GitHub.