### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,19 @@
     "posttest": "npm run lint",
     "lint": "standard"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/motdotla/dotenv-expand"
+  },
+  "bugs": {
+    "url": "https://github.com/motdotla/dotenv-expand/issues"
+  },
+  "author": "Scott Motte <mot@mot.la> (http://mot.la)",
   "keywords": [
     "dotenv",
     "expand",
     "variables"
   ],
-  "author": "motdotla",
   "license": "BSD-2-Clause",
   "devDependencies": {
     "dotenv": "^4.0.0",


### PR DESCRIPTION
I went to the [`npm` page of this package](https://www.npmjs.com/package/dotenv-expand) and wanted to link back to the repo itself, but there wasn't any link available.
Updating these fields will help with that.