### PR TITLE
Fix example environment file link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ var myEnv = dotenv.config()
 dotenvExpand(myEnv)
 ```
 
-See [test/.env](./test/.env) for examples of variable expansion in your `.env`
-file. 
+See [test/.env](https://github.com/desrosj/dotenv-expand/blob/master/test/.env) for examples of variable expansion in
+your `.env` file. 
 


### PR DESCRIPTION
The link to the environment file with examples only works on GitHub. This changes the URL to a full URL so that anyone reading the README on npmjs.com can successfully navigate to the examples.