### PR TITLE
update type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,20 @@
 export = dotenv_expand;
 
 interface DotenvResult {
-    error?: Error;
-    parsed?: {
-        [name: string]: string;
-    };
+  error?: Error;
+  parsed?: {
+    [name: string]: string;
+  };
 }
 
-declare function dotenv_expand(config: DotenvResult): DotenvResult;
+interface DotenvExpandOptions {
+  ignoreProcessEnv?: boolean;
+}
+
+declare function dotenv_expand(
+  config: DotenvResult & DotenvExpandOptions
+): DotenvResult;
 
 declare namespace dotenv_expand {
-    const prototype: {
-    };
+  const prototype: {};
 }


### PR DESCRIPTION
The type definitions were missing the option `ignoreProcessEnv`. Add this in.