### PR TITLE
Fix broken link in npmjs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ var myEnv = dotenv.config()
 dotenvExpand(myEnv)
 ```
 
-See [test/.env](./test/.env) for examples of variable expansion in your `.env`
+See [test/.env](https://github.com/motdotla/dotenv-expand/blob/master/test/.env) for examples of variable expansion in your `.env`
 file. 
 


### PR DESCRIPTION
When viewing the readme in npmjs.com, the `test/.env` link was expanded to `https://www.npmjs.com/package/test/.env`, which is broken.