### PR TITLE
Fixed preload error

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,12 +1,7 @@
 (function () {
-  const dotenvExpand = require('./lib/main')
-  const env = require('dotenv').config(
-    Object.assign(
-      {},
-      require('dotenv/lib/env-options'),
-      require('dotenv/lib/cli-options')(process.argv)
-    )
-  )
+  const { expand: dotenvExpand } = require('./lib/main')
+
+  const env = require('dotenv').config()
 
   return dotenvExpand(env)
 })()


### PR DESCRIPTION
- dotenvExpand function was imported improperly
- dotenv does not export cli-options and env-options, but allows to use the default arguments instead of passing an object