### PR TITLE
Fixes #64

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,12 +1,6 @@
 (function () {
   const dotenvExpand = require('./lib/main').expand;
-  const env = require('dotenv').config(
-    Object.assign(
-      {},
-      require('dotenv/lib/env-options'),
-      require('dotenv/lib/cli-options')(process.argv)
-    )
-  )
+  const env = require('dotenv').config()
 
   return dotenvExpand(env)
 })()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dotenv-expand",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dotenv-expand",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "@types/node": "^17.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotenv-expand",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Expand environment variables using dotenv",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",


### PR DESCRIPTION
This should fix #64.  I'm not sure why we were trying to require `dotenv/lib/env-options` or `dotenv/lib/cli-options`, as `require('dotenv').config()` already does that, we were just duplicating the logic.