### PR TITLE
Add context, add read-only process env option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <img src="https://raw.githubusercontent.com/motdotla/dotenv-expand/master/dotenv-expand.png" alt="dotenv-expand" align="right" />
 
-Dotenv-expand adds variable expansion on top of 
+Dotenv-expand adds variable expansion on top of
 [dotenv](http://github.com/motdotla/dotenv). If you find yourself needing to
 expand environment variables already existing on your machine, then
 dotenv-expand is your tool.
@@ -108,7 +108,11 @@ console.log(obj)
 
 Default: `false`
 
-Turn off writing to `process.env`.
+Type: `boolean | 'read-only'`
+
+Configure how to use `process.env`.
+
+If set to `true`, `process.env` will not be read from nor be written to.
 
 ```js
 const dotenv = {
@@ -123,6 +127,42 @@ console.log(obj.SHOULD_NOT_EXIST) // testing
 console.log(process.env.SHOULD_NOT_EXIST) // undefined
 ```
 
+If set to `'read-only'`, `process.env` will be read from, but not written to.
+
+```js
+process.env.PROCESS_ENV = 'testing'
+const dotenv = {
+  ignoreProcessEnv: 'read-only',
+  parsed: {
+    SHOULD_BE_EXPANDED: '$PROCESS_ENV'
+  }
+}
+const obj = dotenvExpand.expand(dotenv).parsed
+
+console.log(obj.SHOULD_BE_EXPANDED) // testing
+console.log(process.env.SHOULD_BE_EXPANDED) // undefined
+```
+
+##### context
+
+Provide your own environment context when `ignoreProcessEnv` is `true`.
+
+```js
+const dotenv = {
+  ignoreProcessEnv: true,
+  parsed: {
+    EXPANDED_FROM_CONTEXT: '$CONTEXT_VARIABLE',
+  },
+  context: {
+    CONTEXT_VARIABLE: 'testing'
+  }
+}
+const obj = dotenvExpand.expand(dotenv).parsed
+
+console.log(obj.EXPANDED_FROM_CONTEXT) // testing
+```
+
+
 ## FAQ
 
 ### What rules does the expansion engine follow?
@@ -130,7 +170,7 @@ console.log(process.env.SHOULD_NOT_EXIST) // undefined
 The expansion engine roughly has the following rules:
 
 * `$KEY` will expand any env with the name `KEY`
-* `${KEY}` will expand any env with the name `KEY` 
+* `${KEY}` will expand any env with the name `KEY`
 * `\$KEY` will escape the `$KEY` rather than expand
 * `${KEY:-default}` will first attempt to expand any env with the name `KEY`. If not one, then it will return `default`
 

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -2,19 +2,25 @@
 /// <reference types="node" />
 
 export interface DotenvExpandOptions {
-  ignoreProcessEnv?: boolean;
+  ignoreProcessEnv?: boolean | 'read-only';
   error?: Error;
   parsed?: {
+    [name: string]: string;
+  };
+  context?: {
     [name: string]: string;
   }
 }
 
 export interface DotenvExpandOutput {
-  ignoreProcessEnv?: boolean;
+  ignoreProcessEnv?: boolean | 'readonly';
   error?: Error;
   parsed?: {
     [name: string]: string;
   };
+  context?: {
+    [name: string]: string;
+  }
 }
 
 /**

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const rfdc = require('rfdc')
+
 function _interpolate (envValue, environment, config) {
   const matches = envValue.match(/(.?\${*[\w]*(?::-[\w/]*)?}*)/g) || []
 
@@ -41,8 +43,20 @@ function _interpolate (envValue, environment, config) {
 }
 
 function expand (config) {
-  // if ignoring process.env, use a blank object
-  const environment = config.ignoreProcessEnv ? {} : process.env
+  let environment
+
+  switch (config.ignoreProcessEnv) {
+    case 'read-only':
+      environment = rfdc()(process.env)
+      break
+
+    case true:
+      environment = config.context || {}
+      break
+
+    default:
+      environment = process.env
+  }
 
   for (const configKey in config.parsed) {
     const value = Object.prototype.hasOwnProperty.call(environment, configKey) ? environment[configKey] : config.parsed[configKey]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "dotenv-expand",
       "version": "8.0.3",
       "license": "BSD-2-Clause",
+      "dependencies": {
+        "rfdc": "^1.3.0"
+      },
       "devDependencies": {
         "@types/node": "^17.0.8",
         "dotenv": "^16.0.0",
@@ -3384,6 +3387,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+    },
     "node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -6744,6 +6752,11 @@
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "rimraf": {
       "version": "2.6.3",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
   },
   "engines": {
     "node": ">=12"
+  },
+  "dependencies": {
+    "rfdc": "^1.3.0"
   }
 }

--- a/tests/main.js
+++ b/tests/main.js
@@ -266,6 +266,51 @@ describe('dotenv-expand', function () {
       done()
     })
 
+    it('should use `context` if ignoreProcessEnv is set and a context is provided', function (done) {
+      const dotenv = {
+        ignoreProcessEnv: true,
+        context: {
+          CONTEXT: 'testing'
+        },
+        parsed: {
+          CONTEXT_EXPAND: '$CONTEXT'
+        }
+      }
+      const obj = dotenvExpand.expand(dotenv).parsed
+
+      obj.CONTEXT_EXPAND.should.eql('testing')
+      done()
+    })
+
+    it('should use process.env if ignoreProcessEnv is set to read-only', function (done) {
+      process.env.CONTEXT = 'testing'
+      const dotenv = {
+        ignoreProcessEnv: 'read-only',
+        parsed: {
+          CONTEXT_EXPAND: '$CONTEXT'
+        }
+      }
+      const obj = dotenvExpand.expand(dotenv).parsed
+
+      obj.CONTEXT_EXPAND.should.eql('testing')
+      done()
+    })
+
+    it('should not write to process.env if ignoreProcessEnv is set to read-only', function (done) {
+      process.env.CONTEXT = 'testing'
+      const dotenv = {
+        ignoreProcessEnv: 'read-only',
+        parsed: {
+          CONTEXT_EXPAND: '$CONTEXT'
+        }
+      }
+      dotenvExpand.expand(dotenv)
+
+      const evaluation = typeof process.env.CONTEXT_EXPAND
+      evaluation.should.eql('undefined')
+      done()
+    })
+
     it('should expand with default value correctly', function (done) {
       const obj = dotenvExpand.expand(dotenv).parsed
 


### PR DESCRIPTION
This PR addresses #55, as well as provides a route to fixing https://github.com/vitejs/vite/issues/6626

## Updated Options
1. `ignoreProcessEnv`: added `read-only` option, which will read from `process.env` but not write to it.

## New Options
1. `context`: optionally pass your own environment context to be used if `ignoreProcessEnv: true`.