### PR TITLE
[2/2] fixes dotenv-expand/config with env or cli args

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,7 +1,13 @@
 (function () {
   const dotenvExpand = require('./lib/main').expand
 
-  const env = require('dotenv').config()
+  const env = require('dotenv').config(
+    Object.assign(
+      {},
+      require('dotenv/lib/env-options'),
+      require('dotenv/lib/cli-options')(process.argv)
+    )
+  )
 
   return dotenvExpand(env)
 })()


### PR DESCRIPTION
I discovered that when using [dotenv-expand](https://www.npmjs.com/package/dotenv-expand) in preload env and cli args are not working, so I made two pull requests (the former in [dotenv](https://github.com/motdotla/dotenv) and the latter in [dotenv-expand](https://github.com/motdotla/dotenv-expand) to fix it.

I used [dotenv#355](https://github.com/motdotla/dotenv/pull/355) for reference.