### PR TITLE
Fixed minor typo in text

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ That's it. `process.env` now has the expanded keys and values you defined in you
 
 ### Preload
 
-You can use the `--require` (`-r`) [command line option](https://nodejs.org/api/cli.html#cli_r_require_module) to preload dotenv & dotenv-
-. By doing this, you do not need to require and load dotenv or dotenv-expand in your application code. This is the preferred approach when using `import` instead of `require`.
+You can use the `--require` (`-r`) [command line option](https://nodejs.org/api/cli.html#cli_r_require_module) to preload dotenv & dotenv-expand. By doing this, you do not need to require and load dotenv or dotenv-expand in your application code. This is the preferred approach when using `import` instead of `require`.
 
 ```bash
 $ node -r dotenv-expand/config your_script.js


### PR DESCRIPTION
# Fixed minor typo in text
```diff
- You can use the `--require` (`-r`) [command line option](https://nodejs.org/api/cli.html#cli_r_require_module) to preload dotenv & dotenv-.
+ You can use the `--require` (`-r`) [command line option](https://nodejs.org/api/cli.html#cli_r_require_module) to preload dotenv & dotenv-expand.
```