### PR TITLE
Fix of issue #101 when part of the password disappears

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -3,6 +3,7 @@
 
 export interface DotenvExpandOptions {
   ignoreProcessEnv?: boolean;
+  ignoreUndefinedValues?: boolean;
   error?: Error;
   parsed?: {
     [name: string]: string;
@@ -11,6 +12,7 @@ export interface DotenvExpandOptions {
 
 export interface DotenvExpandOutput {
   ignoreProcessEnv?: boolean;
+  ignoreUndefinedValues?: boolean;
   error?: Error;
   parsed?: {
     [name: string]: string;

--- a/lib/main.js
+++ b/lib/main.js
@@ -35,13 +35,16 @@ function _interpolate (envValue, environment, config) {
   if (match != null) {
     const [, group, variableName, defaultValue] = match
 
+    const replacement = environment[variableName] || defaultValue || config.parsed[variableName]
+
+    if (config.ignoreUndefinedValues && typeof replacement === 'undefined') {
+      return envValue
+    }
+
     return _interpolate(
       envValue.replace(
         group,
-        environment[variableName] ||
-          defaultValue ||
-          config.parsed[variableName] ||
-          ''
+        replacement || ''
       ),
       environment,
       config

--- a/tests/main.js
+++ b/tests/main.js
@@ -29,6 +29,7 @@ describe('dotenv-expand', function () {
       }
       const obj = dotenvExpand.expand(dotenv).parsed
 
+      obj.BASIC.should.eql('basic')
       obj.BASIC_EXPAND.should.eql('basic')
       obj.BASIC_EXPAND_SIMPLE.should.eql('basic')
     })
@@ -80,6 +81,30 @@ describe('dotenv-expand', function () {
       const obj = dotenvExpand.expand(dotenv).parsed
 
       obj.ESCAPED_EXPAND.should.eql('$ESCAPED')
+    })
+
+    it('does not expand undefined variables if ignoreUndefinedValues is true', function () {
+      const dotenv = {
+        ignoreUndefinedValues: true,
+        parsed: {
+          SOME_VARIABLE_1: '$SOME_VALUE'
+        }
+      }
+      const obj = dotenvExpand.expand(dotenv).parsed
+
+      obj.SOME_VARIABLE_1.should.eql('$SOME_VALUE')
+    })
+
+    it('does not remove piece of password ignoreUndefinedValues is true', function () {
+      const dotenv = {
+        ignoreUndefinedValues: true,
+        parsed: {
+          SOME_VARIABLE_2: 'somep@$word'
+        }
+      }
+      const obj = dotenvExpand.expand(dotenv).parsed
+
+      obj.SOME_VARIABLE_2.should.eql('somep@$word')
     })
 
     it('does not expand inline escaped dollar sign', function () {


### PR DESCRIPTION
Hello! Please review my suggested fix and we can discuss in comments if that's OK.
Issue is described here https://github.com/motdotla/dotenv-expand/issues/101

### The bug is:
If some environment variable contains a dollar sign ($) this plugin removes symbols after that sign.
In my case, that was a database password (like `ab$defgh@jk`) which became `ab@jk` because of `dotenv-expand`. 

### Suggested solution:
My suggestion is to not replace undefined values by empty strings. But as it's a breaking change, we can introduce config flag like `ignoreUndefinedValues?: boolean` to enable this logics.