### PR TITLE
Fix self-expanding undefined variable with default value.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -32,9 +32,7 @@ function interpolate (value, processEnv, parsed) {
 
       if (parsed[key]) {
         // avoid recursion from EXPAND_SELF=$EXPAND_SELF
-        if (parsed[key] === value) {
-          return parsed[key]
-        } else {
+        if (parsed[key] !== value) {
           return interpolate(parsed[key], processEnv, parsed)
         }
       }

--- a/tests/main.js
+++ b/tests/main.js
@@ -42,7 +42,20 @@ t.test('expands self without a recursive call stack error', ct => {
   }
   const parsed = dotenvExpand.expand(dotenv).parsed
 
-  ct.equal(parsed.EXPAND_SELF, '$EXPAND_SELF') // because it ends up accessing parsed[key].
+  ct.equal(parsed.EXPAND_SELF, '') // because it ends up accessing parsed[key].
+
+  ct.end()
+})
+
+t.test('expands self with undefined variable and default value', ct => {
+  const dotenv = {
+    parsed: {
+      EXPAND_SELF: '${EXPAND_SELF:-default}'
+    }
+  }
+  const parsed = dotenvExpand.expand(dotenv).parsed
+
+  ct.equal(parsed.EXPAND_SELF, 'default')
 
   ct.end()
 })
@@ -466,7 +479,7 @@ t.test('expands self without a recursive call stack error (process.env)', ct => 
   const dotenv = require('dotenv').config({ path: 'tests/.env.test', processEnv: {} })
   const parsed = dotenvExpand.expand(dotenv).parsed
 
-  ct.equal(parsed.EXPAND_SELF, '$EXPAND_SELF') // because it ends up accessing parsed[key].
+  ct.equal(parsed.EXPAND_SELF, '') // because it ends up accessing parsed[key].
 
   ct.end()
 })


### PR DESCRIPTION
Currently

```js
const expanded = dotenvExpand.expand({
  parsed: {
    EXPAND_UNDEFINED: '${UNDEFINED}',
    EXPAND_SELF: '${EXPAND_SELF}',
    EXPAND_UNDEFINED_WITH_DEFAULT: '${UNDEFINED:-default}',
    EXPAND_SELF_WITH_DEFAULT: '${EXPAND_SELF_WITH_DEFAULT:-default}'
  }
})

console.log(expanded.parsed)
```
produces
```js
{
  EXPAND_UNDEFINED: '',          // undefined vars are expanded to an empty string
  EXPAND_SELF: '${EXPAND_SELF}', // but not if undefined is self-referenced!
  EXPAND_UNDEFINED_WITH_DEFAULT: 'default', // default is respected
  EXPAND_SELF_WITH_DEFAULT: '${EXPAND_SELF_WITH_DEFAULT:-default}' // default is ignored
}
```
In short - shelf-referenced expansions leave the values unchanged.

This pull requests changes the result to
```js
{
  EXPAND_UNDEFINED: '', // empty string, as before
  EXPAND_SELF: '', // empty string, because expanding undefined
  EXPAND_UNDEFINED_WITH_DEFAULT: 'default', // default is respected, as before
  EXPAND_SELF_WITH_DEFAULT: 'default' // default value is now respected
}
```