### PR TITLE
fix expand

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -33,7 +33,9 @@ function interpolate (value, processEnv, parsed) {
       if (parsed[key]) {
         // avoid recursion from EXPAND_SELF=$EXPAND_SELF
         if (parsed[key] === value) {
-          return parsed[key]
+          if (!defaultValue) {
+            return parsed[key]
+          }
         } else {
           return interpolate(parsed[key], processEnv, parsed)
         }

--- a/tests/main.js
+++ b/tests/main.js
@@ -566,3 +566,15 @@ t.test('expands recursively but is smart enough to not attempt expansion of a pr
 
   ct.end()
 })
+
+t.test('expand should expand defaults', ct => {
+  const parsed = dotenvExpand.expand({
+    parsed: {
+      UNDEFINED_EXPAND_DEFAULT: '${UNDEFINED_EXPAND_DEFAULT:-default}'
+    },
+    processEnv: {}
+  }).parsed
+
+  ct.equal(parsed.UNDEFINED_EXPAND_DEFAULT, 'default')
+  ct.end()
+})


### PR DESCRIPTION
Fix bug where expand doesn't work with simple defaults. This is how expand is called in vite.

The test contains the example which doesn't parse correctly. Without the fix the test returns `${UNDEFINED_EXPAND_DEFAULT:-default}`

https://github.com/vitejs/vite/blob/889bfc0ada6d6cd356bb7a92efdce96298f82fef/packages/vite/src/node/env.ts#L55